### PR TITLE
Refactor shape vertex/index management & simplify updates.

### DIFF
--- a/assets/skin_generator/skin_generator.py
+++ b/assets/skin_generator/skin_generator.py
@@ -344,7 +344,7 @@ def main() -> None:
 
     with open("output.ron", "w") as file:
         file.write("(\n")
-        file.write("""background_image: Some("synth4_background.png"),\n""")
+        file.write("""stylesheet_image: Some("synth4_background.png"),\n""")
         file.write(f"size: ({WIDTH}, {HEIGHT}),\n")
         file.write(f"padding: ({DEFAULT_PADDING_X}, {DEFAULT_PADDING_Y}),\n")
 

--- a/sunfish-core/src/ui/mod.rs
+++ b/sunfish-core/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod alignment;
 pub mod buffers;
 pub mod coords;
 pub mod editor;
+pub mod packed_shapes;
 pub mod shapes;
 pub mod sprites;
 pub mod styling;

--- a/sunfish-core/src/ui/packed_shapes.rs
+++ b/sunfish-core/src/ui/packed_shapes.rs
@@ -1,0 +1,301 @@
+use std::collections::HashSet;
+
+use lyon::tessellation;
+
+use crate::ui::buffers;
+
+pub type Buffers<T> = tessellation::VertexBuffers<T, u16>;
+
+pub trait Vertex: bytemuck::Zeroable + bytemuck::Pod + Clone {
+    fn descriptor<'a>() -> wgpu::VertexBufferDescriptor<'a>;
+}
+
+/// A Shape captures the CPU side of a single polygon with a
+/// max number of vertices known ahead of time (to simplify
+/// GPU-side memory management).
+pub struct Shape<T: Vertex> {
+    vertices: Vec<T>,
+    indices: Vec<u16>,
+    /// Max vertices and indices allocated for this shape.
+    max_v_count: usize,
+    max_i_count: usize,
+}
+
+impl<T: Vertex> Shape<T> {
+    pub fn new(
+        vertices: Vec<T>,
+        indices: Vec<u16>,
+        max_v_count: usize,
+        max_i_count: usize,
+    ) -> Self {
+        Self {
+            vertices,
+            indices,
+            max_v_count,
+            max_i_count,
+        }
+    }
+
+    pub fn from_lyon(shapes: Buffers<T>, max_v_count: usize, max_i_count: usize) -> Self {
+        Shape {
+            vertices: shapes.vertices,
+            indices: shapes.indices,
+            max_v_count,
+            max_i_count,
+        }
+    }
+
+    fn update(&mut self, vertices: &[T], indices: &[u16]) {
+        // TODO: Copy the slices in place.
+        let vertices = if vertices.len() > self.max_v_count {
+            // TODO: Should we just truncate and log?
+            log::warn!("Shape::update received vertex buffer larger than max_v_count");
+            &vertices[..self.max_v_count]
+        } else {
+            vertices
+        };
+
+        let indices = if indices.len() > self.max_i_count {
+            // TODO: Should we just truncate and log?
+            log::warn!("Shape::update received index buffer larger than max_i_count");
+            &indices[..self.max_i_count]
+        } else {
+            indices
+        };
+
+        // Replace them in-memory.
+        self.vertices.resize(vertices.len(), T::zeroed());
+        self.vertices.clone_from_slice(vertices);
+
+        // TODO: Maybe Shapes and BoundShapes should be merged, then we can
+        // look directly at the offset from ind_ranges.
+        self.indices.resize(indices.len(), 0);
+        self.indices.clone_from_slice(indices);
+    }
+}
+
+pub struct Shapes<T: Vertex> {
+    shapes: Vec<Shape<T>>,
+    shapes_to_update: HashSet<usize>,
+}
+
+impl<T: Vertex> Shapes<T> {
+    pub fn with_capacity(shape_count: usize) -> Self {
+        Self {
+            shapes: Vec::with_capacity(shape_count),
+            shapes_to_update: HashSet::with_capacity(shape_count),
+        }
+    }
+
+    pub fn add(&mut self, shape: Shape<T>) -> usize {
+        let index = self.shapes.len();
+        self.shapes.push(shape);
+        index
+    }
+
+    pub fn update(&mut self, index: usize, vertices: &[T], indices: &[u16]) {
+        self.shapes_to_update.insert(index);
+        if let Some(shape) = self.shapes.get_mut(index) {
+            shape.update(vertices, indices)
+        }
+    }
+}
+
+struct VerRanges(Vec<std::ops::Range<u32>>);
+struct IndRanges(Vec<std::ops::Range<u32>>);
+
+pub struct BoundShapes<T: Vertex> {
+    pub shape_render_pipeline: wgpu::RenderPipeline,
+    buffers: buffers::VertexBuffers<T>,
+    ver_ranges: VerRanges,
+    ind_ranges: IndRanges,
+}
+
+impl<T: Vertex> BoundShapes<T> {
+    pub fn new(
+        device: &wgpu::Device,
+        swapchain_format: &wgpu::TextureFormat,
+        shapes: &Shapes<T>,
+    ) -> Self {
+        let (ver_ranges, ind_ranges, ver_buf, ind_buf) = Self::pack_shapes(shapes);
+        let buffers = buffers::VertexBuffers::new(device, &ver_buf, &ind_buf);
+
+        let shape_vs_module =
+            device.create_shader_module(wgpu::include_spirv!("shader_shape.vert.spv"));
+        let shape_fs_module =
+            device.create_shader_module(wgpu::include_spirv!("shader_shape.frag.spv"));
+
+        let shape_render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("shape_render_pipeline_layout"),
+                bind_group_layouts: &[],
+                push_constant_ranges: &[],
+            });
+
+        let shape_render_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("shape_render_pipeline"),
+                layout: Some(&shape_render_pipeline_layout),
+                vertex_stage: wgpu::ProgrammableStageDescriptor {
+                    module: &shape_vs_module,
+                    entry_point: "main",
+                },
+                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
+                    module: &shape_fs_module,
+                    entry_point: "main",
+                }),
+                // Use the default rasterizer state: no culling, no depth bias
+                rasterization_state: None,
+                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
+                color_states: &[(*swapchain_format).into()],
+                depth_stencil_state: None,
+                vertex_state: wgpu::VertexStateDescriptor {
+                    index_format: wgpu::IndexFormat::Uint16,
+                    vertex_buffers: &[T::descriptor()],
+                },
+                sample_count: 1,
+                sample_mask: !0,
+                alpha_to_coverage_enabled: false,
+            });
+        BoundShapes {
+            shape_render_pipeline,
+            buffers,
+            ver_ranges,
+            ind_ranges,
+        }
+    }
+
+    fn pack_shapes(shapes: &Shapes<T>) -> (VerRanges, IndRanges, Vec<T>, Vec<u16>) {
+        // Compute total buffer size.
+        let tot_ver_buf: usize = shapes.shapes.iter().map(|shape| shape.max_v_count).sum();
+        let tot_ind_buf: usize = shapes.shapes.iter().map(|shape| shape.max_i_count).sum();
+
+        // Round up to nearest 4. TODO: figure out how to get the 4.0
+        let tot_ind_buf = (((tot_ind_buf as f32 / 4.0).ceil()) * 4.0) as usize;
+
+        let mut ver_buf = vec![T::zeroed(); tot_ver_buf];
+        let mut ind_buf = vec![0u16; tot_ind_buf];
+
+        let mut ver_offset = 0;
+        let mut ver_last_offset = 0;
+
+        let mut ind_offset = 0;
+        let mut ind_last_offset = 0;
+
+        let mut ver_ranges = Vec::with_capacity(shapes.shapes.len());
+        let mut ind_ranges = Vec::with_capacity(shapes.shapes.len());
+
+        for shape in &shapes.shapes {
+            let ver_size = shape.max_v_count;
+            let ind_size = shape.max_i_count;
+
+            // Copy vertex and index data; note that the sizes of
+            // them will be <= max_{i,v}_count
+            //
+            // copy into the buffer
+            ver_buf[ver_last_offset..ver_last_offset + shape.vertices.len()]
+                .clone_from_slice(&shape.vertices);
+
+            // We have to offset the indices to account for previous vertices.
+            for (i, vertex_index) in shape.indices.iter().enumerate() {
+                ind_buf[i + ind_last_offset] = vertex_index + ver_last_offset as u16;
+            }
+
+            ver_offset += ver_size;
+            ind_offset += ind_size;
+
+            ver_ranges.push(ver_last_offset as u32..ver_offset as u32);
+            ind_ranges.push(ind_last_offset as u32..ind_offset as u32);
+
+            ver_last_offset = ver_offset;
+            ind_last_offset = ind_offset;
+        }
+        (
+            VerRanges(ver_ranges),
+            IndRanges(ind_ranges),
+            ver_buf,
+            ind_buf,
+        )
+    }
+}
+
+pub fn update<T: Vertex>(
+    device: &wgpu::Device,
+    shapes: &mut Shapes<T>,
+    bound_shapes: &mut BoundShapes<T>,
+    staging_belt: &mut wgpu::util::StagingBelt,
+    encoder: &mut wgpu::CommandEncoder,
+) {
+    // - update the ind_ranges
+    for shape_index in shapes.shapes_to_update.drain() {
+        let shape = &shapes.shapes[shape_index];
+
+        let ver_offset = bound_shapes.ver_ranges.0[shape_index].start as u64;
+        let ver_size = shape.vertices.len() as u64;
+
+        let ind_offset = bound_shapes.ind_ranges.0[shape_index].start as u64;
+        let ind_size = shape.indices.len() as u64;
+
+        // TODO: These calls dig into the guts of buffers; could probably
+        // benefit from a refactor.
+
+        // Update vertices.
+        let ver_elm_size = bound_shapes.buffers.vertices.element_size() as u64;
+        let ver_buf_size = ver_elm_size * ver_size as u64;
+        if ver_buf_size > 0 {
+            staging_belt
+                .write_buffer(
+                    encoder,
+                    &bound_shapes.buffers.vertices.buf,
+                    ver_offset * ver_elm_size,
+                    wgpu::BufferSize::new(ver_buf_size).unwrap(),
+                    device,
+                )
+                .copy_from_slice(bytemuck::cast_slice(&shape.vertices));
+        }
+        let start = bound_shapes.ver_ranges.0[shape_index].start;
+        bound_shapes.ver_ranges.0[shape_index].end = start + ver_size as u32;
+
+        // Update indices.
+        let ind_elm_size = bound_shapes.buffers.indices.element_size() as u64;
+        let ind_buf_size = ind_elm_size * ind_size as u64;
+        if ind_buf_size > 0 {
+            let mut indices_offset = vec![0u16; shape.indices.len()];
+            // We have to offset the indices to account for previous vertices.
+            for (i, vertex_index) in shape.indices.iter().enumerate() {
+                indices_offset[i] = vertex_index + ver_offset as u16;
+            }
+
+            staging_belt
+                .write_buffer(
+                    encoder,
+                    &bound_shapes.buffers.indices.buf,
+                    ind_offset * ind_elm_size,                    //offset
+                    wgpu::BufferSize::new(ind_buf_size).unwrap(), //size
+                    device,
+                )
+                .copy_from_slice(bytemuck::cast_slice(&indices_offset));
+        }
+
+        let start = bound_shapes.ind_ranges.0[shape_index].start;
+        bound_shapes.ind_ranges.0[shape_index].end = start + ind_size as u32;
+    }
+}
+
+pub fn render<'a, T: Vertex>(
+    bound_shapes: &'a BoundShapes<T>,
+    mut rpass: wgpu::RenderPass<'a>,
+) -> wgpu::RenderPass<'a> {
+    rpass.set_pipeline(&bound_shapes.shape_render_pipeline);
+
+    rpass.set_vertex_buffer(0, bound_shapes.buffers.vertices.buf.slice(..));
+    rpass.set_index_buffer(bound_shapes.buffers.indices.buf.slice(..));
+
+    for range in &bound_shapes.ind_ranges.0 {
+        if !range.is_empty() {
+            rpass.draw_indexed(range.clone(), 0, 0..1);
+        }
+    }
+
+    rpass
+}

--- a/sunfish-core/src/ui/shapes.rs
+++ b/sunfish-core/src/ui/shapes.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::mem;
 
 use bytemuck::{Pod, Zeroable};
@@ -17,8 +16,8 @@ use lyon::tessellation::{
 use lyon::tessellation::{FillVertex, StrokeVertex};
 use serde::Deserialize;
 
-use crate::ui::buffers;
 use crate::ui::coords::Rect;
+use crate::ui::packed_shapes;
 
 pub type Buffers = tessellation::VertexBuffers<ShapeVertex, u16>;
 
@@ -165,7 +164,13 @@ pub struct ShapeVertex {
 }
 
 impl ShapeVertex {
-    pub fn descriptor<'a>() -> wgpu::VertexBufferDescriptor<'a> {
+    pub fn new(position: [f32; 3], color: [f32; 3]) -> Self {
+        Self { position, color }
+    }
+}
+
+impl packed_shapes::Vertex for ShapeVertex {
+    fn descriptor<'a>() -> wgpu::VertexBufferDescriptor<'a> {
         wgpu::VertexBufferDescriptor {
             stride: mem::size_of::<Self>() as wgpu::BufferAddress,
             step_mode: wgpu::InputStepMode::Vertex,
@@ -182,9 +187,6 @@ impl ShapeVertex {
                 },
             ],
         }
-    }
-    pub fn new(position: [f32; 3], color: [f32; 3]) -> Self {
-        Self { position, color }
     }
 }
 
@@ -215,268 +217,6 @@ impl<'a> lyon::tessellation::FillVertexConstructor<ShapeVertex> for ShapeVertexB
             color: self.color,
         }
     }
-}
-
-/// A Shape captures the CPU side of a single polygon with a
-/// max number of vertices known ahead of time (to simplify
-/// GPU-side memory management).
-pub struct Shape {
-    vertices: Vec<ShapeVertex>,
-    indices: Vec<u16>,
-    /// Max vertices and indices allocated for this shape.
-    max_v_count: usize,
-    max_i_count: usize,
-}
-
-impl Shape {
-    pub fn new(
-        vertices: Vec<ShapeVertex>,
-        indices: Vec<u16>,
-        max_v_count: usize,
-        max_i_count: usize,
-    ) -> Self {
-        Self {
-            vertices,
-            indices,
-            max_v_count,
-            max_i_count,
-        }
-    }
-
-    pub fn from_lyon(shapes: Buffers, max_v_count: usize, max_i_count: usize) -> Self {
-        Shape {
-            vertices: shapes.vertices,
-            indices: shapes.indices,
-            max_v_count,
-            max_i_count,
-        }
-    }
-
-    fn update(&mut self, vertices: &[ShapeVertex], indices: &[u16]) {
-        // TODO: Copy the slices in place.
-        let vertices = if vertices.len() > self.max_v_count {
-            // TODO: Should we just truncate and log?
-            log::warn!("Shape::update received vertex buffer larger than max_v_count");
-            &vertices[..self.max_v_count]
-        } else {
-            vertices
-        };
-
-        let indices = if indices.len() > self.max_i_count {
-            // TODO: Should we just truncate and log?
-            log::warn!("Shape::update received index buffer larger than max_i_count");
-            &indices[..self.max_i_count]
-        } else {
-            indices
-        };
-
-        // Replace them in-memory.
-        self.vertices.resize(vertices.len(), ShapeVertex::zeroed());
-        self.vertices.clone_from_slice(vertices);
-
-        // TODO: Maybe Shapes and BoundShapes should be merged, then we can
-        // look directly at the offset from ind_ranges.
-        self.indices.resize(indices.len(), 0);
-        self.indices.clone_from_slice(indices);
-    }
-}
-
-pub struct Shapes {
-    shapes: Vec<Shape>,
-    shapes_to_update: HashSet<usize>,
-}
-
-impl Shapes {
-    pub fn with_capacity(shape_count: usize) -> Self {
-        Self {
-            shapes: Vec::with_capacity(shape_count),
-            shapes_to_update: HashSet::with_capacity(shape_count),
-        }
-    }
-
-    pub fn add(&mut self, shape: Shape) -> usize {
-        let index = self.shapes.len();
-        self.shapes.push(shape);
-        index
-    }
-
-    pub fn update(&mut self, index: usize, vertices: &[ShapeVertex], indices: &[u16]) {
-        self.shapes_to_update.insert(index);
-        if let Some(shape) = self.shapes.get_mut(index) {
-            shape.update(vertices, indices)
-        }
-    }
-}
-
-struct VerRanges(Vec<std::ops::Range<u32>>);
-struct IndRanges(Vec<std::ops::Range<u32>>);
-
-pub struct BoundShapes {
-    pub shape_render_pipeline: wgpu::RenderPipeline,
-    buffers: buffers::VertexBuffers<ShapeVertex>,
-    ver_ranges: VerRanges,
-    ind_ranges: IndRanges,
-    shadow_vertices: Vec<ShapeVertex>,
-    shadow_indices: Vec<u16>,
-}
-
-impl BoundShapes {
-    pub fn new(
-        device: &wgpu::Device,
-        swapchain_format: &wgpu::TextureFormat,
-        shapes: &Shapes,
-    ) -> Self {
-        let (ver_ranges, ind_ranges, ver_buf, ind_buf) = Self::pack_shapes(shapes);
-        let buffers = buffers::VertexBuffers::new(device, &ver_buf, &ind_buf);
-
-        let shape_vs_module =
-            device.create_shader_module(wgpu::include_spirv!("shader_shape.vert.spv"));
-        let shape_fs_module =
-            device.create_shader_module(wgpu::include_spirv!("shader_shape.frag.spv"));
-
-        let shape_render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("shape_render_pipeline_layout"),
-                bind_group_layouts: &[],
-                push_constant_ranges: &[],
-            });
-
-        let shape_render_pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("shape_render_pipeline"),
-                layout: Some(&shape_render_pipeline_layout),
-                vertex_stage: wgpu::ProgrammableStageDescriptor {
-                    module: &shape_vs_module,
-                    entry_point: "main",
-                },
-                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                    module: &shape_fs_module,
-                    entry_point: "main",
-                }),
-                // Use the default rasterizer state: no culling, no depth bias
-                rasterization_state: None,
-                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-                color_states: &[(*swapchain_format).into()],
-                depth_stencil_state: None,
-                vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
-                    vertex_buffers: &[ShapeVertex::descriptor()],
-                },
-                sample_count: 1,
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
-            });
-        BoundShapes {
-            shape_render_pipeline,
-            buffers,
-            ver_ranges,
-            ind_ranges,
-            shadow_vertices: ver_buf,
-            shadow_indices: ind_buf,
-        }
-    }
-
-    fn pack_shapes(shapes: &Shapes) -> (VerRanges, IndRanges, Vec<ShapeVertex>, Vec<u16>) {
-        // Compute total buffer size.
-        let tot_ver_buf: usize = shapes.shapes.iter().map(|shape| shape.max_v_count).sum();
-        let tot_ind_buf: usize = shapes.shapes.iter().map(|shape| shape.max_i_count).sum();
-
-        // Round up to nearest 4. TODO: figure out how to get the 4.0
-        let tot_ind_buf = (((tot_ind_buf as f32 / 4.0).ceil()) * 4.0) as usize;
-
-        let mut ver_buf = vec![ShapeVertex::zeroed(); tot_ver_buf];
-        let mut ind_buf = vec![0u16; tot_ind_buf];
-
-        let mut ver_offset = 0;
-        let mut ver_last_offset = 0;
-
-        let mut ind_offset = 0;
-        let mut ind_last_offset = 0;
-
-        let mut ver_ranges = Vec::with_capacity(shapes.shapes.len());
-        let mut ind_ranges = Vec::with_capacity(shapes.shapes.len());
-
-        for shape in &shapes.shapes {
-            let ver_size = shape.max_v_count;
-            let ind_size = shape.max_i_count;
-
-            // Copy vertex and index data; note that the sizes of
-            // them will be <= max_{i,v}_count
-            //
-            // copy into the buffer
-            ver_buf[ver_last_offset..ver_last_offset + shape.vertices.len()]
-                .clone_from_slice(&shape.vertices);
-
-            // We have to offset the indices to account for previous vertices.
-            for (i, vertex_index) in shape.indices.iter().enumerate() {
-                ind_buf[i + ind_last_offset] = vertex_index + ver_last_offset as u16;
-            }
-
-            ver_offset += ver_size;
-            ind_offset += ind_size;
-
-            ver_ranges.push(ver_last_offset as u32..ver_offset as u32);
-            ind_ranges.push(ind_last_offset as u32..ind_offset as u32);
-
-            ver_last_offset = ver_offset;
-            ind_last_offset = ind_offset;
-        }
-        (
-            VerRanges(ver_ranges),
-            IndRanges(ind_ranges),
-            ver_buf,
-            ind_buf,
-        )
-    }
-
-    fn update_shadow_buffer(&mut self, shapes: &mut Shapes) {
-        // TODO:
-        // - update the ind_ranges
-        for shape_index in shapes.shapes_to_update.drain() {
-            let shape = &shapes.shapes[shape_index];
-            let ver_offset = self.ver_ranges.0[shape_index].start;
-            let ver_offset_usize = ver_offset as usize;
-            let ver_size = shape.vertices.len();
-
-            self.shadow_vertices[ver_offset_usize..ver_offset_usize + ver_size]
-                .copy_from_slice(&shape.vertices);
-
-            let start = self.ver_ranges.0[shape_index].start;
-            self.ver_ranges.0[shape_index].end = start + ver_size as u32;
-
-            // =======
-            // Indices:
-            // =======
-            let ind_offset = self.ind_ranges.0[shape_index].start as usize;
-            let ind_size = shape.indices.len();
-
-            // We have to offset the indices to account for previous vertices.
-            for (i, vertex_index) in shape.indices.iter().enumerate() {
-                self.shadow_indices[i + ind_offset] = vertex_index + ver_offset as u16;
-            }
-
-            let start = self.ind_ranges.0[shape_index].start;
-            self.ind_ranges.0[shape_index].end = start + ind_size as u32;
-        }
-    }
-}
-
-pub fn render<'a>(
-    bound_shapes: &'a BoundShapes,
-    mut rpass: wgpu::RenderPass<'a>,
-) -> wgpu::RenderPass<'a> {
-    rpass.set_pipeline(&bound_shapes.shape_render_pipeline);
-
-    rpass.set_vertex_buffer(0, bound_shapes.buffers.vertices.buf.slice(..));
-    rpass.set_index_buffer(bound_shapes.buffers.indices.buf.slice(..));
-
-    for range in &bound_shapes.ind_ranges.0 {
-        if !range.is_empty() {
-            rpass.draw_indexed(range.clone(), 0, 0..1);
-        }
-    }
-
-    rpass
 }
 
 #[derive(Debug)]
@@ -561,124 +301,6 @@ impl Arc {
         }
 
         buffers
-    }
-}
-
-pub fn update(
-    device: &wgpu::Device,
-    shapes: &mut Shapes,
-    bound_shapes: &mut BoundShapes,
-    staging_belt: &mut wgpu::util::StagingBelt,
-    encoder: &mut wgpu::CommandEncoder,
-) {
-    _delta_update(device, shapes, bound_shapes, staging_belt, encoder);
-}
-
-pub fn _update_whole_copy(
-    device: &wgpu::Device,
-    shapes: &mut Shapes,
-    bound_shapes: &mut BoundShapes,
-    staging_belt: &mut wgpu::util::StagingBelt,
-    encoder: &mut wgpu::CommandEncoder,
-) {
-    // We have to update the entire buffer each time.
-    //
-    // So, to minimize copies, the bound shapes object keeps shadow vectors
-    // of the vertices and indices.
-    bound_shapes.update_shadow_buffer(shapes);
-
-    // let (ver_ranges, ind_ranges, ver_buf, ind_buf) = BoundShapes::pack_shapes(shapes);
-    // bound_shapes.ver_ranges = ver_ranges;
-    // bound_shapes.ind_ranges = ind_ranges;
-
-    // Now copy the whole chunk
-    let ver_elm_size = bound_shapes.buffers.vertices.element_size() as u64;
-    let ver_buf_size = bound_shapes.buffers.vertices.size as u64 * ver_elm_size;
-    staging_belt
-        .write_buffer(
-            encoder,
-            &bound_shapes.buffers.vertices.buf,
-            0,
-            wgpu::BufferSize::new(ver_buf_size).unwrap(), //size
-            device,
-        )
-        .copy_from_slice(bytemuck::cast_slice(&bound_shapes.shadow_vertices));
-
-    // Indices
-    let ind_elm_size = bound_shapes.buffers.indices.element_size() as u64;
-    let ind_buf_size = bound_shapes.buffers.indices.size as u64 * ind_elm_size;
-    staging_belt
-        .write_buffer(
-            encoder,
-            &bound_shapes.buffers.indices.buf,
-            0,
-            wgpu::BufferSize::new(ind_buf_size).unwrap(), //size
-            device,
-        )
-        .copy_from_slice(bytemuck::cast_slice(&bound_shapes.shadow_indices));
-}
-
-pub fn _delta_update(
-    device: &wgpu::Device,
-    shapes: &mut Shapes,
-    bound_shapes: &mut BoundShapes,
-    staging_belt: &mut wgpu::util::StagingBelt,
-    encoder: &mut wgpu::CommandEncoder,
-) {
-    // TODO:
-    // - update the ind_ranges
-    for shape_index in shapes.shapes_to_update.drain() {
-        let shape = &shapes.shapes[shape_index];
-
-        let ver_offset = bound_shapes.ver_ranges.0[shape_index].start as u64;
-        let ver_size = shape.vertices.len() as u64;
-
-        let ind_offset = bound_shapes.ind_ranges.0[shape_index].start as u64;
-        let ind_size = shape.indices.len() as u64;
-
-        // TODO: These calls dig into the guts of buffers; could probably
-        // benefit from a refactor.
-
-        // Update vertices.
-        let ver_elm_size = bound_shapes.buffers.vertices.element_size() as u64;
-        let ver_buf_size = ver_elm_size * ver_size as u64;
-        if ver_buf_size > 0 {
-            staging_belt
-                .write_buffer(
-                    encoder,
-                    &bound_shapes.buffers.vertices.buf,
-                    ver_offset * ver_elm_size,
-                    wgpu::BufferSize::new(ver_buf_size).unwrap(),
-                    device,
-                )
-                .copy_from_slice(bytemuck::cast_slice(&shape.vertices));
-        }
-        let start = bound_shapes.ver_ranges.0[shape_index].start;
-        bound_shapes.ver_ranges.0[shape_index].end = start + ver_size as u32;
-
-        // Update indices.
-        let ind_elm_size = bound_shapes.buffers.indices.element_size() as u64;
-        let ind_buf_size = ind_elm_size * ind_size as u64;
-        if ind_buf_size > 0 {
-            let mut indices_offset = vec![0u16; shape.indices.len()];
-            // We have to offset the indices to account for previous vertices.
-            for (i, vertex_index) in shape.indices.iter().enumerate() {
-                indices_offset[i] = vertex_index + ver_offset as u16;
-            }
-
-            staging_belt
-                .write_buffer(
-                    encoder,
-                    &bound_shapes.buffers.indices.buf,
-                    ind_offset * ind_elm_size,                    //offset
-                    wgpu::BufferSize::new(ind_buf_size).unwrap(), //size
-                    device,
-                )
-                .copy_from_slice(bytemuck::cast_slice(&indices_offset));
-        }
-
-        let start = bound_shapes.ind_ranges.0[shape_index].start;
-        bound_shapes.ind_ranges.0[shape_index].end = start + ind_size as u32;
     }
 }
 

--- a/sunfish-core/src/ui/sprites.rs
+++ b/sunfish-core/src/ui/sprites.rs
@@ -23,16 +23,12 @@ impl SpriteVertex {
 
     /// Create a new vertex corrected to screen metrics.
     pub fn correct(&self, screen_metrics: &ScreenMetrics) -> Self {
-        // let x = screen_metrics.norm_x_to_corrected(self.position[0]) * 2.0 - 1.0;
-        // let y = screen_metrics.norm_y_to_corrected(self.position[1]) * -2.0 + 1.0;
         let x0 = self.position[0];
         let y0 = self.position[1];
         let x1 = screen_metrics.norm_x_to_corrected(x0);
         let y1 = screen_metrics.norm_y_to_corrected(y0);
         let x = x1 * 2.0 - 1.0;
         let y = y1 * -2.0 + 1.0;
-        // TODO: let x = screen_metrics.norm_x_to_corrected(x);
-        // TODO: let y = screen_metrics.norm_y_to_corrected(y);
         SpriteVertex {
             position: [x, y, 0.0],
             tex_coords: self.tex_coords,
@@ -87,10 +83,9 @@ pub struct SpriteSheet {
 impl SpriteSheet {
     pub fn new(device: &wgpu::Device, queue: &wgpu::Queue, filename: &str) -> Self {
         let texture_bytes = std::fs::read(filename).unwrap();
-        println!("Loading spritesheet...");
+        log::info!("Loading spritesheet...");
         let texture =
             texture::Texture::from_bytes(device, queue, &texture_bytes, filename).unwrap();
-        //let _ = texture::Texture::from_png(&device, &queue, &filename, &filename);
         SpriteSheet {
             sprites: vec![],
             texture,
@@ -141,7 +136,7 @@ impl BoundSpriteSheet {
         let buffers =
             Self::create_buffers(device, &mut vertices, &mut indices, sheet, screen_metrics);
 
-        println!("Creating sprite bind groups...");
+        log::info!("Creating sprite bind groups...");
         let sprite_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 entries: &[
@@ -185,7 +180,7 @@ impl BoundSpriteSheet {
         let sprite_fs_module =
             device.create_shader_module(wgpu::include_spirv!("shader_sprite.frag.spv"));
 
-        println!("Creating pipelines...");
+        log::info!("Creating pipelines...");
         let sprite_render_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("sprite_render_pipeline_layout"),
@@ -247,7 +242,6 @@ impl BoundSpriteSheet {
 
         let mut i = 0;
         for (sprite_i, sprite) in sheet.sprites.iter().enumerate() {
-            // TODO:
             let (x, y) = sprite.pos.unpack();
             let (w, h) = sprite.size.unpack();
 
@@ -263,25 +257,21 @@ impl BoundSpriteSheet {
             );
             let vi = sprite_i * 4;
             vertices[vi] = SpriteVertex {
-                //position: [x * 2.0 - 1.0, y * -2.0 + 1.0, 0.0],
                 position: [x, y, 0.0],
                 tex_coords: [src_x, src_y],
             }
             .correct(screen_metrics);
             vertices[vi + 1] = SpriteVertex {
-                //position: [xw * 2.0 - 1.0, y * -2.0 + 1.0, 0.0],
                 position: [xw, y, 0.0],
                 tex_coords: [src_xw, src_y],
             }
             .correct(screen_metrics);
             vertices[vi + 2] = SpriteVertex {
-                //position: [xw * 2.0 - 1.0, yh * -2.0 + 1.0, 0.0],
                 position: [xw, yh, 0.0],
                 tex_coords: [src_xw, src_yh],
             }
             .correct(screen_metrics);
             vertices[vi + 3] = SpriteVertex {
-                // position: [x * 2.0 - 1.0, yh * -2.0 + 1.0, 0.0],
                 position: [x, yh, 0.0],
                 tex_coords: [src_x, src_yh],
             }

--- a/sunfish-core/src/ui/styling.rs
+++ b/sunfish-core/src/ui/styling.rs
@@ -13,7 +13,7 @@ pub struct Styling {
     pub size: (i32, i32),
     pub background: Background,
     pub padding: (f32, f32),
-    pub background_image: Option<String>,
+    pub stylesheet_image: Option<String>,
     elements: Vec<Element>,
 }
 

--- a/sunfish-core/src/ui/window.rs
+++ b/sunfish-core/src/ui/window.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync;
 use std::sync::atomic::AtomicU32;
 use std::time::{Duration, Instant};
@@ -16,7 +17,8 @@ use winit::{
 use crate::params::sync::{Subscriber, Synchronizer};
 use crate::params::{Params, ParamsMeta};
 use crate::ui::coords::{Coord2, UserVec2, Vec2};
-use crate::ui::shapes;
+use crate::ui::packed_shapes::{self, BoundShapes, Shapes};
+use crate::ui::shapes::{self, ScreenMetrics, ShapeVertex};
 use crate::ui::sprites;
 use crate::ui::styling;
 use crate::ui::widgets::{LabelPosition, Widget, WidgetId};
@@ -124,14 +126,14 @@ struct RenderState {
     sc_desc: wgpu::SwapChainDescriptor,
     swap_chain: wgpu::SwapChain,
     last_position: winit::dpi::PhysicalPosition<f64>,
-    screen_metrics: shapes::ScreenMetrics,
+    screen_metrics: ScreenMetrics,
     _aspect_ratio: f32,
 
     background: [f64; 3],
-    background_image: sprites::SpriteSheet,
-    bound_background_image: sprites::BoundSpriteSheet,
-    shapes: shapes::Shapes,
-    bound_shapes: shapes::BoundShapes,
+    spritesheet: sprites::SpriteSheet,
+    bound_spritesheet: sprites::BoundSpriteSheet,
+    shapes: Shapes<shapes::ShapeVertex>,
+    bound_shapes: BoundShapes<ShapeVertex>,
     glyph_brush: GlyphBrush<(), ab_glyph::FontArc, RandomXxHashBuilder64>,
     staging_belt: wgpu::util::StagingBelt,
 
@@ -156,8 +158,7 @@ impl RenderState {
 
         let size = window.inner_size();
 
-        let screen_metrics =
-            shapes::ScreenMetrics::new(size.width, size.height, window.scale_factor());
+        let screen_metrics = ScreenMetrics::new(size.width, size.height, window.scale_factor());
 
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
         let surface = unsafe { instance.create_surface(window) };
@@ -186,11 +187,11 @@ impl RenderState {
         /////////////////////////////////////////////////////////////////
         // Sprites
         /////////////////////////////////////////////////////////////////
-        let background_base_filename = styling
-            .background_image
+        let stylesheet_base_filename = styling
+            .stylesheet_image
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| "synthsheet.png".to_string());
+            .expect("Stylesheet image could not be loaded");
 
         // Go up one folder
         let assets_folder = {
@@ -200,7 +201,7 @@ impl RenderState {
             base.join("assets")
         };
 
-        let filename = assets_folder.join(background_base_filename);
+        let filename = assets_folder.join(stylesheet_base_filename);
         log::info!("Sprite base filename: {:?}", filename);
 
         let mut spritesheet =
@@ -226,7 +227,7 @@ impl RenderState {
         }
         // add all widgets
         let mut widget_map = HashMap::new();
-        let mut shapes = shapes::Shapes::with_capacity(widgets.len());
+        let mut shapes = Shapes::with_capacity(widgets.len());
         for mut widget in widgets.drain(..) {
             widget.initialize(&screen_metrics, &mut spritesheet, &mut shapes);
             widget_map.insert(widget.id, widget);
@@ -243,7 +244,7 @@ impl RenderState {
         // Shapes
         /////////////////////////////////////////////////////////////////
 
-        let bound_shapes = shapes::BoundShapes::new(&device, &swapchain_format, &shapes);
+        let bound_shapes = BoundShapes::new(&device, &swapchain_format, &shapes);
 
         ///////////////////////////
 
@@ -299,8 +300,8 @@ impl RenderState {
 
             default_padding: Coord2::new(styling.padding.0, styling.padding.1),
 
-            background_image: spritesheet,
-            bound_background_image: bound_spritesheet,
+            spritesheet,
+            bound_spritesheet,
             shapes,
             bound_shapes,
             glyph_brush,
@@ -323,38 +324,70 @@ impl RenderState {
         self.sc_desc.width = new_size.width;
         self.sc_desc.height = new_size.height;
         self.swap_chain = self.device.create_swap_chain(&self.surface, &self.sc_desc);
-        self.screen_metrics = shapes::ScreenMetrics::new(
+        self.screen_metrics = ScreenMetrics::new(
             new_size.width,
             new_size.height,
             self.screen_metrics.scale_factor,
         );
-        self.update_widgets(widgets, params);
+        self.update_all_widgets(widgets, params);
         // TODO: Update only specific widgets.
         for (_widget_id, widget) in widgets.iter_mut() {
             widget.on_resize(
                 &self.screen_metrics,
-                &mut self.background_image,
+                &mut self.spritesheet,
                 &mut self.shapes,
                 params,
             );
         }
     }
 
-    fn update_widgets(&mut self, widgets: &mut WidgetMap, params: &Synchronizer) {
+    fn update_all_widgets(&mut self, widgets: &mut WidgetMap, params: &Synchronizer) {
         // TODO: Update only specific widgets.
         for (_widget_id, widget) in widgets.iter_mut() {
             widget.update(
                 &self.screen_metrics,
-                &mut self.background_image,
+                &mut self.spritesheet,
                 &mut self.shapes,
                 params,
             );
         }
-        self.bound_background_image.update(
-            &self.device,
-            &self.background_image,
-            &self.screen_metrics,
-        );
+        self.bound_spritesheet
+            .update(&self.device, &self.spritesheet, &self.screen_metrics);
+    }
+
+    fn update_widgets(
+        &mut self,
+        widgets: &mut WidgetMap,
+        params: &Synchronizer,
+        updates: &HashSet<WidgetId>,
+    ) {
+        for (widget_id, widget) in widgets.iter_mut() {
+            if updates.contains(widget_id) {
+                widget.update(
+                    &self.screen_metrics,
+                    &mut self.spritesheet,
+                    &mut self.shapes,
+                    params,
+                );
+            }
+        }
+    }
+
+    fn update_widget(&mut self, widgets: &mut WidgetMap, params: &Synchronizer, id: &WidgetId) {
+        if let Some(widget) = widgets.get_mut(id) {
+            log::info!("update_widget: updating id={:?}", id);
+            widget.update(
+                &self.screen_metrics,
+                &mut self.spritesheet,
+                &mut self.shapes,
+                params,
+            );
+        } else {
+            log::warn!("update_widget: widget not found! id={:?}", id);
+        }
+        // Temporary.
+        self.bound_spritesheet
+            .update(&self.device, &self.spritesheet, &self.screen_metrics);
     }
 
     async fn render(&mut self, widgets: &mut WidgetMap) {
@@ -375,7 +408,7 @@ impl RenderState {
             });
 
         // Note: read wgpu docs before reordering any of these operations.
-        shapes::update(
+        packed_shapes::update(
             &self.device,
             &mut self.shapes,
             &mut self.bound_shapes,
@@ -400,9 +433,8 @@ impl RenderState {
                 depth_stencil_attachment: None,
             });
             // Render sprites first, then shapes.
-            let rpass =
-                sprites::render(&self.bound_background_image, rpass, &self.background_image);
-            shapes::render(&self.bound_shapes, rpass);
+            let rpass = sprites::render(&self.bound_spritesheet, rpass, &self.spritesheet);
+            packed_shapes::render(&self.bound_shapes, rpass);
         }
 
         for widget in widgets.values_mut() {
@@ -556,6 +588,7 @@ pub struct SynthGui {
     #[allow(dead_code)]
     meta: sync::Arc<ParamsMeta>,
     param_sync_poller: Poller,
+    widgets_to_update: HashSet<WidgetId>,
 
     _ignore_next_resized_event: bool,
 }
@@ -570,8 +603,10 @@ impl SynthGui {
         let meta = (parameters.grabbed.as_ref().unwrap()).meta.clone();
 
         let meta = sync::Arc::new(meta);
+        let param_count = meta.count();
         let state = async_std::task::block_on(State::new(sync::Arc::clone(&meta), window, styling));
         let param_sync_duration = Duration::from_secs_f32(1.0 / PARAM_SYNC_PER_SEC);
+
         let mut synth_gui = SynthGui {
             state,
 
@@ -579,6 +614,7 @@ impl SynthGui {
             subscriber,
             meta,
             param_sync_poller: Poller::new(param_sync_duration),
+            widgets_to_update: HashSet::with_capacity(param_count),
 
             _ignore_next_resized_event: false,
         };
@@ -683,9 +719,15 @@ impl SynthGui {
                                 }
                             }
                             InteractiveState::Dragging { id, .. } => {
+                                log::info!("Dragging (id: {:?})", id);
                                 if let Some(widget) = self.state.widgets.get_mut(&id) {
                                     if let Some(new_value) = widget.on_drag_done() {
                                         self.update_param(&id, new_value);
+                                        self.state.render_state.update_widget(
+                                            &mut self.state.widgets,
+                                            &self.parameters,
+                                            &id,
+                                        );
                                     }
                                 }
                                 if input_state == ElementState::Released {
@@ -713,6 +755,7 @@ impl SynthGui {
                     if let InteractiveState::Dragging { id, mouse } =
                         &mut self.state.interactive_state
                     {
+                        let id = *id;
                         mouse.pos.x = self.state.mouse_pos.x;
                         mouse.pos.y = self.state.mouse_pos.y;
                         let df = if self.state.modifier_active_ctrl {
@@ -720,14 +763,15 @@ impl SynthGui {
                         } else {
                             DRAG_FACTOR_NORMAL
                         };
-                        if let Some(widget) = self.state.widgets.get_mut(id) {
+                        if let Some(widget) = self.state.widgets.get_mut(&id) {
                             let tentative_value = widget.on_dragging(mouse, &df);
-                            let id = *id;
                             self.update_param(&id, tentative_value);
                         }
-                        self.state
-                            .render_state
-                            .update_widgets(&mut self.state.widgets, &self.parameters);
+                        self.state.render_state.update_widget(
+                            &mut self.state.widgets,
+                            &self.parameters,
+                            &id,
+                        );
                     }
                     self.state.render_state.last_position = position;
                     window.request_redraw();
@@ -766,6 +810,7 @@ impl SynthGui {
         let mut any_changed = false;
         if let Ok(guard) = self.subscriber.changes.try_lock() {
             let changes = &(*guard);
+            self.widgets_to_update.clear();
             for (updated_eparam, updated_value) in changes {
                 any_changed = true;
                 let widget_id = WidgetId::Bound {
@@ -774,11 +819,14 @@ impl SynthGui {
                 if let Some(widget) = self.state.widgets.get_mut(&widget_id) {
                     widget.value = *updated_value;
                 }
+                self.widgets_to_update.insert(widget_id);
             }
             if any_changed {
-                self.state
-                    .render_state
-                    .update_widgets(&mut self.state.widgets, &self.parameters);
+                self.state.render_state.update_widgets(
+                    &mut self.state.widgets,
+                    &self.parameters,
+                    &self.widgets_to_update,
+                );
             }
         }
         any_changed

--- a/sunfish-core/styling.ron
+++ b/sunfish-core/styling.ron
@@ -1,5 +1,5 @@
 (
-background_image: Some("synth4_background.png"),
+stylesheet_image: Some("synth4_background.png"),
 size: (1500, 997),
 padding: (0.005, 0.001),
 background: Sprite(dest_rect: Rect(pos: (0.000000, 0.000000, 1.000000, 0.664667)), src_rect: Rect(pos: (0.000000, 0.000000, 1500.000000, 997.000000))),


### PR DESCRIPTION
We would like to apply the "delta-based" changes to textures to improve GUI performance (as we deallocate and reallocate all sprites every time we render). The first step is to decouple that logic from the concrete type (in this case, `ShapeVertex`).